### PR TITLE
feat: detect system language and add language switcher

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { StyleSheet } from 'react-native';
 import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import BottomNav from './components/BottomNav';
+import LangChanger from './components/LangChanger';
 import LoginScreen from './screens/LoginScreen';
 import RegistrationScreen from './screens/RegistrationScreen';
 import './i18n';
@@ -78,15 +78,7 @@ export default function App() {
                     </Stack.Navigator>
                 )}
             </NavigationContainer>
+            <LangChanger />
         </SafeAreaProvider>
     );
 }
-
-const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        backgroundColor: '#14213D',
-        padding: 15,
-        color: '#008CBA',
-    },
-});

--- a/components/LangChanger.js
+++ b/components/LangChanger.js
@@ -1,29 +1,56 @@
-import React, { useState } from "react";
-import { View, Text, Switch } from "react-native";
+import React, { useEffect, useState } from "react";
+import { Text, TouchableOpacity, View } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Ionicons } from "@expo/vector-icons";
 import { useTranslation } from "react-i18next";
 import { styles } from "../styles/components/LangChanger.styles";
+import {
+  LANGUAGE_STORAGE_KEY,
+  normalizeLanguage,
+} from "../utils/language";
 
 const LangChanger = () => {
   const { i18n } = useTranslation();
-  const [isEnglish, setIsEnglish] = useState(i18n.language === "en");
+  const [currentLanguage, setCurrentLanguage] = useState(
+    normalizeLanguage(i18n.language),
+  );
 
-  // Language toggler
-  const toggleLanguage = () => {
-    const newLang = isEnglish ? "pt" : "en";
-    i18n.changeLanguage(newLang);
-    setIsEnglish(!isEnglish);
+  useEffect(() => {
+    const loadSavedLanguage = async () => {
+      const savedLanguage = await AsyncStorage.getItem(LANGUAGE_STORAGE_KEY);
+
+      if (!savedLanguage) {
+        return;
+      }
+
+      const normalizedLanguage = normalizeLanguage(savedLanguage);
+      await i18n.changeLanguage(normalizedLanguage);
+      setCurrentLanguage(normalizedLanguage);
+    };
+
+    loadSavedLanguage();
+  }, [i18n]);
+
+  const toggleLanguage = async () => {
+    const newLanguage = currentLanguage === "en" ? "pt" : "en";
+
+    await i18n.changeLanguage(newLanguage);
+    await AsyncStorage.setItem(LANGUAGE_STORAGE_KEY, newLanguage);
+    setCurrentLanguage(newLanguage);
   };
 
-  // Switch component to change language
   return (
     <View style={styles.container}>
-      <Text style={styles.label}>{isEnglish ? "EN" : "PT"}</Text>
-      <Switch
-        onValueChange={toggleLanguage}
-        value={isEnglish}
-        trackColor={{ false: "#0c3a9c", true: "#81b0ff" }}
-        thumbColor={isEnglish ? "#86898f" : "#f4f3f4"}
-      />
+      <TouchableOpacity
+        style={styles.button}
+        onPress={toggleLanguage}
+        activeOpacity={0.85}
+        accessibilityRole="button"
+        accessibilityLabel="Alterar idioma"
+      >
+        <Ionicons name="language-outline" size={22} color="#14213D" />
+        <Text style={styles.label}>{currentLanguage.toUpperCase()}</Text>
+      </TouchableOpacity>
     </View>
   );
 };

--- a/i18n.js
+++ b/i18n.js
@@ -1,5 +1,6 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import { getSystemLanguage, DEFAULT_LANGUAGE } from './utils/language';
 
 // load the Language .json files
 import en from './locales/en.json'
@@ -8,8 +9,8 @@ import pt from './locales/pt.json'
 // I18N Set up
 i18n.use(initReactI18next)
     .init({
-        lng: 'en',
-        fallbackLng: 'en',
+        lng: getSystemLanguage(),
+        fallbackLng: DEFAULT_LANGUAGE,
         compatibilityJSON: 'v3',
         interpolation: {
             escapeValue: false,

--- a/styles/components/LangChanger.styles.js
+++ b/styles/components/LangChanger.styles.js
@@ -3,13 +3,27 @@ import { StyleSheet } from "react-native";
 export const styles = StyleSheet.create({
   container: {
     position: "absolute",
-    top: 10,
-    right: 10,
+    top: 48,
+    right: 16,
+    zIndex: 100,
+    elevation: 8,
+  },
+  button: {
     flexDirection: "row",
     alignItems: "center",
+    gap: 6,
+    backgroundColor: "#FFFFFF",
+    borderRadius: 24,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    shadowColor: "#000000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.18,
+    shadowRadius: 4,
   },
   label: {
-    fontSize: 16,
-    marginRight: 5,
+    color: "#14213D",
+    fontSize: 13,
+    fontWeight: "700",
   },
 });

--- a/utils/language.js
+++ b/utils/language.js
@@ -1,0 +1,19 @@
+import * as Localization from "expo-localization";
+
+export const LANGUAGE_STORAGE_KEY = "preferredLanguage";
+export const DEFAULT_LANGUAGE = "pt";
+export const SUPPORTED_LANGUAGES = ["en", "pt"];
+
+export const normalizeLanguage = (language) => {
+  const languageCode = language?.split("-")[0]?.toLowerCase();
+
+  return SUPPORTED_LANGUAGES.includes(languageCode)
+    ? languageCode
+    : DEFAULT_LANGUAGE;
+};
+
+export const getSystemLanguage = () => {
+  const [locale] = Localization.getLocales();
+
+  return normalizeLanguage(locale?.languageTag || locale?.languageCode);
+};


### PR DESCRIPTION
### Objective
Update the frontend to be able to switch languages between pt-BR and en-US.

## What Was Done
- Added system locale detection with `expo-localization`.
- Initialized i18n using the user's device language when supported.
- Added Portuguese fallback for unsupported system languages.
- Added a fixed app-wide language switcher button.
- Persisted the user's selected language with `AsyncStorage`.

## Tests
- Ran `npm test -- --runInBand`.
- Manual inspection validating inline form errors.

## Related Issues